### PR TITLE
Restore (some) JUnit Tests

### DIFF
--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -32,4 +32,26 @@ defined('MOODLE_INTERNAL') || die();
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class repository_owncloud_generator extends testing_repository_generator {
+
+    /**
+     * Creates an issuer and a user.
+     * @return array
+     */
+    public function test_create_preparation () {
+        $generator = advanced_testcase::getDataGenerator();
+        $data = array();
+        $issuerdata = new stdClass();
+        $issuerdata->name = "Service";
+        $issuerdata->clientid = "Clientid";
+        $issuerdata->clientsecret = "Secret";
+        $issuerdata->loginscopes = "openid profile email";
+        $issuerdata->loginscopesoffline = "openid profile email";
+        $issuerdata->baseurl = "";
+        $issuerdata->image = "aswdf";
+        
+        $data['issuerdata'] = $issuerdata;
+        $user = $generator->create_user();
+        $data['user'] = $user;
+        return $data;
+    }
 }

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -48,7 +48,7 @@ class repository_owncloud_generator extends testing_repository_generator {
         $issuerdata->loginscopesoffline = "openid profile email";
         $issuerdata->baseurl = "";
         $issuerdata->image = "aswdf";
-        
+
         $data['issuerdata'] = $issuerdata;
         $user = $generator->create_user();
         $data['user'] = $user;

--- a/tests/repository_owncloud_test.php
+++ b/tests/repository_owncloud_test.php
@@ -64,12 +64,14 @@ class repository_owncloud_testcase extends advanced_testcase {
         $data->image = "aswdf";
         $issuer = $api->create_issuer($data);
         $this->issuer = $issuer;
-        $this->api = $api;
 
+
+        // Create Endpoints for issuer.
         $this->create_endpoint_test("ocs_endpoint");
         $this->create_endpoint_test("authorization_endpoint");
         $this->create_endpoint_test("webdav_endpoint", "https://www.default.de/webdav/index.php");
         $this->create_endpoint_test("token_endpoint");
+
         // Params for the config form.
         $typeparams = array('type' => 'owncloud', 'visible' => 1, 'issuerid' => $issuer->get('id'), 'validissuers' => '');
 
@@ -176,7 +178,7 @@ class repository_owncloud_testcase extends advanced_testcase {
             }
         }
         if (!empty($idwebdav)) {
-            $this->api->delete_endpoint($idwebdav);
+            \core\oauth2\api::delete_endpoint($idwebdav);
         }
         $boolean = $this->invokeMethod($this->repo, "is_valid_issuer", array('issuer' => $this->issuer));
         $this->assertFalse($boolean);
@@ -187,7 +189,7 @@ class repository_owncloud_testcase extends advanced_testcase {
         $this->assertTrue($boolean);
 
         if (!empty($idocs)) {
-            $this->api->delete_endpoint($idocs);
+            \core\oauth2\api::delete_endpoint($idocs);
         }
         $boolean = $this->invokeMethod($this->repo, "is_valid_issuer", array('issuer' => $this->issuer));
         $this->assertFalse($boolean);
@@ -197,7 +199,7 @@ class repository_owncloud_testcase extends advanced_testcase {
         $this->assertTrue($boolean);
 
         if (!empty($idauth)) {
-            $this->api->delete_endpoint($idauth);
+            \core\oauth2\api::delete_endpoint($idauth);
         }
         $boolean = $this->invokeMethod($this->repo, "is_valid_issuer", array('issuer' => $this->issuer));
         $this->assertFalse($boolean);
@@ -207,7 +209,7 @@ class repository_owncloud_testcase extends advanced_testcase {
         $this->assertTrue($boolean);
 
         if (!empty($idtoken)) {
-            $this->api->delete_endpoint($idtoken);
+            \core\oauth2\api::delete_endpoint($idtoken);
         }
         $boolean = $this->invokeMethod($this->repo, "is_valid_issuer", array('issuer' => $this->issuer));
         $this->assertFalse($boolean);
@@ -227,7 +229,7 @@ class repository_owncloud_testcase extends advanced_testcase {
         $endpoint->name = $endpointtype;
         $endpoint->url = $url;
         $endpoint->issuerid = $this->issuer->get('id');
-        $return = $this->api->create_endpoint($endpoint);
+        $return = \core\oauth2\api::create_endpoint($endpoint);
         return $return;
     }
 

--- a/tests/repository_owncloud_test.php
+++ b/tests/repository_owncloud_test.php
@@ -35,44 +35,46 @@ class repository_owncloud_testcase extends advanced_testcase {
 
     private $issuer = null;
 
+    private $api = null;
+
+    /*
+    * @expectedException PHPUnit_Framework_Error_Warning
+    */
     protected function setUp() {
         global $DB;
         $this->resetAfterTest(true);
-
-        // Params for the config form.
-        $typeparams = array('type' => 'owncloud', 'visible' => 0, 'issuerid' => 1, 'validissuers' => '');
 
         // First, create a owncloud repository type and instance.
         $generator = $this->getDataGenerator()->get_plugin_generator('repository_owncloud');
 
         $this->setAdminUser();
         $api = new \core\oauth2\api();
+
         $data = new stdClass();
         $data->name = "Service";
         $data->clientid = "Clientid";
         $data->clientsecret = "Secret";
         $data->loginscopes = "openid profile email";
         $data->loginscopesoffline = "openid profile email";
-        $data->baseurl = "www.baseurl.de";
-        $data->image = "";
+        $data->baseurl = "";
+        $data->image = "aswdf";
         $issuer = $api->create_issuer($data);
+        $this->issuer = $issuer;
+        $this->api = $api;
 
-        $endpoint = new stdClass();
-        $endpoint->name = "token";
-        $endpoint->url = "https://www.someurl.de";
-        $endpoint->issuerid = $issuer->get('id');
-        $endpoint = $api->create_endpoint($endpoint);
-        $generator->test_create_preparation();
+        $this->create_endpoint_test('token_endpoint');
+        // Params for the config form.
+        $typeparams = array('type' => 'owncloud', 'visible' => 1, 'issuerid' => $issuer->get('id'), 'validissuers' => '');
+
         $reptype = $generator->create_type($typeparams);
 
         // Then insert a name for the instance into the database.
-        /*$instance = $DB->get_record('repository_instances', array('typeid' => $reptype->id));
+        $instance = $DB->get_record('repository_instances', array('typeid' => $reptype->id));
         $DB->update_record('repository_instances', (object) array('id' => $instance->id, 'name' => 'ownCloud'));
 
         // At last, create a repository_owncloud object from the instance id.
-        // TODO: Function is called on null, for some reason the repo is not created.
         $this->repo = new repository_owncloud($instance->id);
-        $this->repo->options['typeid'] = $reptype->id;*/
+        $this->repo->options['typeid'] = $reptype->id;
     }
 
     /**
@@ -89,6 +91,104 @@ class repository_owncloud_testcase extends advanced_testcase {
             ->willReturn('www.filepath.de');
 
         // $stub->doSomething() returns $stub
-        $this->assertSame('www.filepath.de', $stub->get_endpoint_url("what"));
+        $this->assertSame('www.filepath.de', $stub->get_endpoint_url("test"));
     }
+    /**
+     * Checks the is_visible method in case the repository is set to hidden in the database.
+     */
+    public function test_is_visible_parent_false() {
+        global $DB;
+        $id = $this->repo->options['typeid'];
+
+        // Check, if the method returns false, when the repository is set to visible in the database
+        // and the client configuration data is complete.
+        $DB->update_record('repository', (object) array('id' => $id, 'visible' => 0));
+
+        $this->assertFalse($this->repo->is_visible());
+    }
+
+    /**
+     * Test weather the repo is disabled, however always returns true.
+     */
+    public function test_repo_creation() {
+        $this->create_endpoint_test("ocs_endpoint");
+        $this->create_endpoint_test("authorization_endpoint");
+        $this->create_endpoint_test("webdav_endpoint");
+        $this->create_endpoint_test("token_endpoint");
+
+        $issuerid = get_config('owncloud', 'issuerid');
+
+        // Config saves the right id
+        $this->assertEquals($this->issuer->get('id'), $issuerid);
+
+        // Function that is used in construct method returns the right id.
+        $constructissuer = \core\oauth2\api::get_issuer($issuerid);
+        $this->assertEquals($this->issuer->get('id'), $constructissuer->get('id'));
+
+        $issuerenabled = $constructissuer->get('enabled');
+        
+        $this->assertEquals(true, $issuerenabled);
+        //TODO Repo should be enabled however disabled = true
+        $this->assertFalse($this->repo->disabled);
+
+    }
+
+    /**
+     * Comparable to is_valid issuer()
+     */
+    public function test_endpoints(){
+        $issuerid = get_config('owncloud', 'issuerid');
+
+        // Config saves the right id
+        $this->assertEquals($this->issuer->get('id'), $issuerid);
+
+        // Function that is used in construct method returns the right id.
+        $constructissuer = \core\oauth2\api::get_issuer($issuerid);
+        // Creating endpoints
+        $this->create_endpoint_test("ocs_endpoint");
+        $this->create_endpoint_test("authorization_endpoint");
+        $this->create_endpoint_test("webdav_endpoint");
+        $this->create_endpoint_test("token_endpoint");
+
+        // Executes the is valid_issuer function does return True.
+        $endpointwebdav = false;
+        $endpointocs = false;
+        $endpointtoken = false;
+        $endpointauth = false;
+        $endpoints = \core\oauth2\api::get_endpoints($constructissuer);
+        foreach ($endpoints as $endpoint) {
+            $name = $endpoint->get('name');
+            switch ($name) {
+                case 'webdav_endpoint':
+                    $endpointwebdav = true;
+                    break;
+                case 'ocs_endpoint':
+                    $endpointocs = true;
+                    break;
+                case 'token_endpoint':
+                    $endpointtoken = true;
+                    break;
+                case 'authorization_endpoint':
+                    $endpointauth = true;
+                    break;
+            }
+        }
+        $boolean = $endpointwebdav && $endpointocs && $endpointtoken && $endpointauth;
+        $this->assertTrue($boolean);
+    }
+
+    /**
+     * @param $endpointtype
+     * @param string $url
+     * @return mixed
+     */
+    protected function create_endpoint_test($endpointtype, $url="https://www.default.de") {
+        $endpoint = new stdClass();
+        $endpoint->name = $endpointtype;
+        $endpoint->url = $url;
+        $endpoint->issuerid = $this->issuer->get('id');
+        $return = $this->api->create_endpoint($endpoint);
+        return $return;
+    }
+
 }

--- a/tests/repository_owncloud_test.php
+++ b/tests/repository_owncloud_test.php
@@ -33,13 +33,62 @@ class repository_owncloud_testcase extends advanced_testcase {
     /** @var null|repository_owncloud the repository_owncloud object, which the tests are run on. */
     private $repo = null;
 
-    /**
-     * Sets up the tested minor repository_owncloud object and all data records which are
-     * needed to initialize the repository.
-     */
+    private $issuer = null;
+
     protected function setUp() {
         global $DB;
         $this->resetAfterTest(true);
+
+        // Params for the config form.
+        $typeparams = array('type' => 'owncloud', 'visible' => 0, 'issuerid' => 1, 'validissuers' => '');
+
+        // First, create a owncloud repository type and instance.
+        $generator = $this->getDataGenerator()->get_plugin_generator('repository_owncloud');
+
+        $this->setAdminUser();
+        $api = new \core\oauth2\api();
+        $data = new stdClass();
+        $data->name = "Service";
+        $data->clientid = "Clientid";
+        $data->clientsecret = "Secret";
+        $data->loginscopes = "openid profile email";
+        $data->loginscopesoffline = "openid profile email";
+        $data->baseurl = "www.baseurl.de";
+        $data->image = "";
+        $issuer = $api->create_issuer($data);
+
+        $endpoint = new stdClass();
+        $endpoint->name = "token";
+        $endpoint->url = "https://www.someurl.de";
+        $endpoint->issuerid = $issuer->get('id');
+        $endpoint = $api->create_endpoint($endpoint);
+        $generator->test_create_preparation();
+        $reptype = $generator->create_type($typeparams);
+
+        // Then insert a name for the instance into the database.
+        /*$instance = $DB->get_record('repository_instances', array('typeid' => $reptype->id));
+        $DB->update_record('repository_instances', (object) array('id' => $instance->id, 'name' => 'ownCloud'));
+
+        // At last, create a repository_owncloud object from the instance id.
+        // TODO: Function is called on null, for some reason the repo is not created.
+        $this->repo = new repository_owncloud($instance->id);
+        $this->repo->options['typeid'] = $reptype->id;*/
     }
 
+    /**
+     * Dummy test for mock.
+     */
+
+    public function testReturnSelf()
+    {
+        // Create a stub for the SomeClass class.
+        $stub = $this->createMock(\core\oauth2\issuer::class);
+
+        // Configure the stub.
+        $stub->method('get_endpoint_url')
+            ->willReturn('www.filepath.de');
+
+        // $stub->doSomething() returns $stub
+        $this->assertSame('www.filepath.de', $stub->get_endpoint_url("what"));
+    }
 }

--- a/tests/repository_owncloud_test.php
+++ b/tests/repository_owncloud_test.php
@@ -28,6 +28,10 @@ defined('MOODLE_INTERNAL') || die();
 
 global $CFG;
 
+/**
+ * Class repository_owncloud_testcase
+ * @group repository_owncloud
+ */
 class repository_owncloud_testcase extends advanced_testcase {
 
     /** @var null|repository_owncloud the repository_owncloud object, which the tests are run on. */
@@ -62,7 +66,10 @@ class repository_owncloud_testcase extends advanced_testcase {
         $this->issuer = $issuer;
         $this->api = $api;
 
-        $this->create_endpoint_test('token_endpoint');
+        $this->create_endpoint_test("ocs_endpoint");
+        $this->create_endpoint_test("authorization_endpoint");
+        $this->create_endpoint_test("webdav_endpoint", "https://www.default.de/webdav/index.php");
+        $this->create_endpoint_test("token_endpoint");
         // Params for the config form.
         $typeparams = array('type' => 'owncloud', 'visible' => 1, 'issuerid' => $issuer->get('id'), 'validissuers' => '');
 
@@ -111,10 +118,6 @@ class repository_owncloud_testcase extends advanced_testcase {
      * Test weather the repo is disabled, however always returns true.
      */
     public function test_repo_creation() {
-        $this->create_endpoint_test("ocs_endpoint");
-        $this->create_endpoint_test("authorization_endpoint");
-        $this->create_endpoint_test("webdav_endpoint");
-        $this->create_endpoint_test("token_endpoint");
 
         $issuerid = get_config('owncloud', 'issuerid');
 
@@ -128,9 +131,7 @@ class repository_owncloud_testcase extends advanced_testcase {
         $issuerenabled = $constructissuer->get('enabled');
         
         $this->assertEquals(true, $issuerenabled);
-        //TODO Repo should be enabled however disabled = true
         $this->assertFalse($this->repo->disabled);
-
     }
 
     /**
@@ -145,10 +146,6 @@ class repository_owncloud_testcase extends advanced_testcase {
         // Function that is used in construct method returns the right id.
         $constructissuer = \core\oauth2\api::get_issuer($issuerid);
         // Creating endpoints
-        $this->create_endpoint_test("ocs_endpoint");
-        $this->create_endpoint_test("authorization_endpoint");
-        $this->create_endpoint_test("webdav_endpoint");
-        $this->create_endpoint_test("token_endpoint");
 
         // Executes the is valid_issuer function does return True.
         $endpointwebdav = false;

--- a/tests/repository_owncloud_test.php
+++ b/tests/repository_owncloud_test.php
@@ -37,32 +37,25 @@ class repository_owncloud_testcase extends advanced_testcase {
     /** @var null|repository_owncloud the repository_owncloud object, which the tests are run on. */
     private $repo = null;
 
+    /** @var null|core\oauth2\issuer which belongs to the repository_owncloud object.*/
     private $issuer = null;
 
-    private $api = null;
-
-    /*
-    * @expectedException PHPUnit_Framework_Error_Warning
-    */
+    /**
+     * SetUp to create an repository instance.
+     */
     protected function setUp() {
         global $DB;
         $this->resetAfterTest(true);
 
-        // First, create a owncloud repository type and instance.
-        $generator = $this->getDataGenerator()->get_plugin_generator('repository_owncloud');
-
+        // Admin is neccessary to create api and issuer objects.
         $this->setAdminUser();
-        $api = new \core\oauth2\api();
 
-        $data = new stdClass();
-        $data->name = "Service";
-        $data->clientid = "Clientid";
-        $data->clientsecret = "Secret";
-        $data->loginscopes = "openid profile email";
-        $data->loginscopesoffline = "openid profile email";
-        $data->baseurl = "";
-        $data->image = "aswdf";
-        $issuer = $api->create_issuer($data);
+        $generator = $this->getDataGenerator()->get_plugin_generator('repository_owncloud');
+        $data = $generator->test_create_preparation();
+        //TODO: Auslagern in Generator
+        // Create the issuer.
+        
+        $issuer = \core\oauth2\api::create_issuer($data['issuerdata']);
         $this->issuer = $issuer;
 
 


### PR DESCRIPTION
As part of the migration to the new OAuth API, we disabled the JUnit tests as they tested against the old API. This PR recreates some of the JUnit tests, now for the new API.