### PR TITLE
Improve use of OCS

### DIFF
--- a/classes/configuration_exception.php
+++ b/classes/configuration_exception.php
@@ -15,7 +15,7 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
- * Exception for when a client configuration data is missing.
+ * Exception for when client configuration data is missing.
  *
  * @package    repository_owncloud
  * @copyright  2017 Project seminar (Learnweb, University of Münster)
@@ -25,6 +25,14 @@
 namespace repository_owncloud;
 
 defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Exception for when client configuration data is missing.
+ *
+ * @package    repository_owncloud
+ * @copyright  2017 Project seminar (Learnweb, University of Münster)
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 
 class configuration_exception extends \moodle_exception {
 

--- a/classes/ocs_client.php
+++ b/classes/ocs_client.php
@@ -51,10 +51,11 @@ class ocs_client extends rest {
      * @throws configuration_exception Exception if critical endpoints are missing.
      */
     public function __construct(client $oauthclient) {
-
         parent::__construct($oauthclient);
+
         $issuer = $oauthclient->get_issuer();
         $this->ocsendpoint = $issuer->get_endpoint_url('ocs');
+
         if ($this->ocsendpoint === false) {
             throw new configuration_exception('Endpoint ocs_endpoint not defined.');
         }

--- a/classes/ocs_client.php
+++ b/classes/ocs_client.php
@@ -1,0 +1,86 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * REST interface to ownCloud's implementation of Open Collaboration Services.
+ *
+ * @package    repository_owncloud
+ * @copyright  2017 Jan Dageförde (Learnweb, University of Münster)
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+namespace repository_owncloud;
+
+use core\oauth2\client;
+use core\oauth2\rest;
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * REST interface to ownCloud's implementation of Open Collaboration Services.
+ *
+ * @copyright  2017 Jan Dageförde (Learnweb, University of Münster)
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class ocs_client extends rest {
+
+    const SHARE_TYPE_PUBLIC = 3;
+    const SHARE_PERMISSION_READ = 1;
+
+    /**
+     * OCS endpoint as configured for the used issuer.
+     * @var string
+     */
+    private $ocsendpoint;
+
+    /**
+     * Get endpoint URLs from the used issuer to use them in get_api_functions().
+     * @param client $oauthclient OAuth-authenticated ownCloud client
+     * @throws configuration_exception Exception if critical endpoints are missing.
+     */
+    public function __construct(client $oauthclient) {
+
+        parent::__construct($oauthclient);
+        $issuer = $oauthclient->get_issuer();
+        $this->ocsendpoint = $issuer->get_endpoint_url('ocs');
+        if ($this->ocsendpoint === false) {
+            throw new configuration_exception('Endpoint ocs_endpoint not defined.');
+        }
+    }
+
+    /**
+     * Define relevant functions of the OCS API.
+     *
+     * Docs:
+     * create_share: https://doc.owncloud.org/server/10.0/developer_manual/core/ocs-share-api.html#create-a-new-share
+     *
+     */
+    public function get_api_functions() {
+        return [
+            'create_share' => [
+                'endpoint' => $this->ocsendpoint,
+                'method' => 'post',
+                'args' => [
+                    'path' => PARAM_TEXT, // Could be PARAM_PATH, we really don't want to enforce a Moodle understanding of paths.
+                    'shareType' => PARAM_INT,
+                    'publicUpload' => PARAM_RAW, // Actually Boolean, but neither String-Boolean ('false') nor PARAM_BOOL (0/1).
+                    'permissions' => PARAM_INT
+                ],
+                'response' => 'text/xml'
+            ],
+        ];
+    }
+
+}

--- a/classes/ocs_client.php
+++ b/classes/ocs_client.php
@@ -31,6 +31,7 @@ defined('MOODLE_INTERNAL') || die();
 /**
  * REST interface to ownCloud's implementation of Open Collaboration Services.
  *
+ * @package    repository_owncloud
  * @copyright  2017 Jan Dageförde (Learnweb, University of Münster)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
@@ -82,6 +83,27 @@ class ocs_client extends rest {
                 'response' => 'text/xml'
             ],
         ];
+    }
+
+    /**
+     * In POST requests, Moodle's REST API assumes that params are
+     * - transmitted as part of the URL or
+     * - expressed in JSON.
+     * Neither is true; we are passing an array to $functionargs which is then put into CURLOPT_POSTFIELDS.
+     * Curl assumes the content type to be `multipart/form-data` then, but the Moodle REST API tries to put
+     * a JSON content type. As a result, clients would fail.
+     * To make this less tedious to use, we assume that the params-as-array-in-$functionargs is the default for us.
+     *
+     * @param string $functionname
+     * @param array $functionargs
+     * @return object|string
+     */
+    public function call($functionname, $functionargs, $rawpost = false, $contenttype = false) {
+        if ($rawpost === false && $contenttype === false) {
+            return parent::call($functionname, $functionargs, false, 'multipart/form-data');
+        } else {
+            return parend::call($functionname, $functionargs, $rawpost, $contenttype);
+        }
     }
 
 }

--- a/classes/ocs_client.php
+++ b/classes/ocs_client.php
@@ -102,7 +102,7 @@ class ocs_client extends rest {
         if ($rawpost === false && $contenttype === false) {
             return parent::call($functionname, $functionargs, false, 'multipart/form-data');
         } else {
-            return parend::call($functionname, $functionargs, $rawpost, $contenttype);
+            return parent::call($functionname, $functionargs, $rawpost, $contenttype);
         }
     }
 

--- a/classes/request_exception.php
+++ b/classes/request_exception.php
@@ -18,7 +18,7 @@
  * Exception for when an OCS request fails
  *
  * @package    repository_owncloud
- * @copyright  2017 Project seminar (Learnweb, University of Münster)
+ * @copyright  2017 Jan Dageförde (Learnweb, University of Münster)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
@@ -26,12 +26,18 @@ namespace repository_owncloud;
 
 defined('MOODLE_INTERNAL') || die();
 
+/**
+ * Exception for when an OCS request fails
+ *
+ * @package    repository_owncloud
+ * @copyright  2017 Jan Dageförde (Learnweb, University of Münster)
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
 class request_exception extends \moodle_exception {
 
     /**
-     * Constructor
-     * This exception is used when the configuration of the plugin can not be processed or database entries are
-     * missing.
+     * An OCS request has failed.
+     *
      * @param string $hint optional param for additional information of the problem
      * @param string $debuginfo detailed information how to fix problem
      */

--- a/classes/request_exception.php
+++ b/classes/request_exception.php
@@ -1,0 +1,41 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Exception for when an OCS request fails
+ *
+ * @package    repository_owncloud
+ * @copyright  2017 Project seminar (Learnweb, University of Münster)
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+namespace repository_owncloud;
+
+defined('MOODLE_INTERNAL') || die();
+
+class request_exception extends \moodle_exception {
+
+    /**
+     * Constructor
+     * This exception is used when the configuration of the plugin can not be processed or database entries are
+     * missing.
+     * @param string $hint optional param for additional information of the problem
+     * @param string $debuginfo detailed information how to fix problem
+     */
+    public function __construct($hint = '', $debuginfo = null) {
+        parent::__construct('request_exception', 'repository_owncloud', '', $hint, $debuginfo);
+    }
+}

--- a/lang/en/repository_owncloud.php
+++ b/lang/en/repository_owncloud.php
@@ -43,3 +43,4 @@ $string['oauth2serviceslink'] = '<a href="{$a}" title="Link to OAuth 2 services 
 
 // Exceptions.
 $string['configuration_exception'] = 'An error in the configuration of the OAuth 2 client occurred: {$a}';
+$string['request_exception'] = 'A request to ownCloud has failed: {$a}';

--- a/lib.php
+++ b/lib.php
@@ -58,6 +58,11 @@ class repository_owncloud extends repository {
      * @var \repository_owncloud\owncloud_client
      */
     private $dav = null;
+    /**
+     * OCS client that uses the Open Collaboration Services REST API.
+     * @var ocs_client
+     */
+    private $ocsclient;
 
     /**
      * repository_owncloud constructor.

--- a/lib.php
+++ b/lib.php
@@ -588,12 +588,6 @@ class repository_owncloud extends repository {
         // Contains all file/folder information and is required to build the file/folder tree.
         $ret['list'] = array();
 
-        // If admin, add reference to repository settings.
-        $sitecontext = context_system::instance();
-        if (has_capability('moodle/site:config', $sitecontext)) {
-            $settingsurl = new moodle_url('/admin/repository.php');
-            $ret['manage'] = $settingsurl->out();
-        }
         return $ret;
     }
 }

--- a/lib.php
+++ b/lib.php
@@ -140,7 +140,7 @@ class repository_owncloud extends repository {
 
     /**
      * Check if an issuer provides all endpoints that we require.
-     * @param $issuer An issuer.
+     * @param \core\oauth2\issuer $issuer An issuer.
      * @return bool True, if all endpoints exist; false otherwise.
      */
     private static function is_valid_issuer($issuer) {
@@ -191,6 +191,8 @@ class repository_owncloud extends repository {
     }
 
     /**
+     * This plugin does not support global search.
+     *
      * @return bool Always false, as global search is unsupported.
      */
     public function global_search() {
@@ -344,7 +346,14 @@ class repository_owncloud extends repository {
     }
 
     /**
-     * Method that generates a reference link to the chosen file.
+     * Repository method that serves the referenced file (created e.g. via get_link).
+     * All parameters are there for compatibility with superclass, but they are ignored.
+     *
+     * @param stored_file $storedfile (ignored)
+     * @param int $lifetime (ignored)
+     * @param int $filter (ignored)
+     * @param bool $forcedownload (ignored)
+     * @param array $options (ignored)
      */
     public function send_file($storedfile, $lifetime=86400 , $filter=0, $forcedownload=false, array $options = null) {
         // Delivers a download link to the concerning file.
@@ -436,7 +445,6 @@ class repository_owncloud extends repository {
     /**
      * Create an instance for this plug-in
      *
-     * @static
      * @param string $type the type of the repository
      * @param int $userid the user id
      * @param stdClass $context the context

--- a/lib.php
+++ b/lib.php
@@ -313,8 +313,8 @@ class repository_owncloud extends repository {
         }
 
         if ((string)$xml->meta->status !== 'ok') {
-            throw new \repository_owncloud\request_exception(sprintf('(%s) %s',
-                trim($xml->meta->statuscode), $xml->meta->message));
+            throw new \repository_owncloud\request_exception(
+                sprintf('(%s) %s', $xml->meta->statuscode, $xml->meta->message));
         }
 
         // Take the share link and convert it into a download link.

--- a/lib.php
+++ b/lib.php
@@ -79,7 +79,10 @@ class repository_owncloud extends repository {
         } catch (dml_missing_record_exception $e) {
             // A repository is marked as disabled when no issuer is present.
             $this->disabled = true;
-        } try {
+            return;
+        }
+
+        try {
             // Check the webdavendpoint.
             $this->parse_endpoint_url('webdav');
         } catch (\repository_owncloud\configuration_exception $e) {
@@ -87,17 +90,19 @@ class repository_owncloud extends repository {
             // or it fails to parse, because all operations concerning files
             // rely on the webdav endpoint.
             $this->disabled = true;
+            return;
         }
+
         if (!$this->issuer) {
             $this->disabled = true;
+            return;
         } else if (!$this->issuer->get('enabled')) {
             // In case the Issuer is not enabled, the repository is disabled.
             $this->disabled = true;
+            return;
         } else if (!self::is_valid_issuer($this->issuer)) {
             // Check if necessary endpoints are present.
             $this->disabled = true;
-        }
-        if ($this->disabled) {
             return;
         }
 

--- a/lib.php
+++ b/lib.php
@@ -298,7 +298,6 @@ class repository_owncloud extends repository {
      *
      */
     public function get_link($url) {
-        //
         $ocsparams = [
             'path' => $url,
             'shareType' => ocs_client::SHARE_TYPE_PUBLIC,

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -15,9 +15,9 @@
 // along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
 
 /**
+ * Data generator for repository plugin.
  *
  * @package    repository_owncloud
- * @category   test
  * @copyright  2017 Project seminar (Learnweb, University of Münster)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
@@ -25,9 +25,9 @@
 defined('MOODLE_INTERNAL') || die();
 
 /**
+ * Data generator for repository plugin.
  *
- * @package    repository_sciebo
- * @category   test
+ * @package    repository_owncloud
  * @copyright  2017 Project seminar (Learnweb, University of Münster)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
@@ -51,6 +51,7 @@ class repository_owncloud_generator extends testing_repository_generator {
         $issuer = \core\oauth2\api::create_issuer($issuerdata);
         return $issuer;
     }
+
     /**
      * Creates four endpoints.
      * @param int $issuerid
@@ -62,11 +63,14 @@ class repository_owncloud_generator extends testing_repository_generator {
         $this->test_create_single_endpoint($issuerid, "webdav_endpoint", "https://www.default.test/webdav/index.php");
         $this->test_create_single_endpoint($issuerid, "token_endpoint");
     }
+
     /**
-     * @param $endpointtype
+     * Create a single endpoint.
+     *
      * @param int $issuerid
+     * @param string $endpointtype
      * @param string $url
-     * @return mixed
+     * @return \core\oauth2\endpoint An instantiated endpoint
      */
     public function test_create_single_endpoint($issuerid, $endpointtype, $url="https://www.default.test") {
         $endpoint = new stdClass();

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -59,7 +59,7 @@ class repository_owncloud_generator extends testing_repository_generator {
     public function test_create_endpoints ($issuerid) {
         $this->test_create_single_endpoint($issuerid, "ocs_endpoint");
         $this->test_create_single_endpoint($issuerid, "authorization_endpoint");
-        $this->test_create_single_endpoint($issuerid, "webdav_endpoint", "https://www.default.de/webdav/index.php");
+        $this->test_create_single_endpoint($issuerid, "webdav_endpoint", "https://www.default.test/webdav/index.php");
         $this->test_create_single_endpoint($issuerid, "token_endpoint");
     }
     /**
@@ -68,7 +68,7 @@ class repository_owncloud_generator extends testing_repository_generator {
      * @param string $url
      * @return mixed
      */
-    public function test_create_single_endpoint($issuerid, $endpointtype, $url="https://www.default.de") {
+    public function test_create_single_endpoint($issuerid, $endpointtype, $url="https://www.default.test") {
         $endpoint = new stdClass();
         $endpoint->name = $endpointtype;
         $endpoint->url = $url;

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -28,7 +28,7 @@ defined('MOODLE_INTERNAL') || die();
  * Class repository_owncloud_testcase
  * @group repository_owncloud
  */
-class repository_owncloud_testcase extends advanced_testcase {
+class repository_owncloud_lib_testcase extends advanced_testcase {
 
     /** @var null|\repository_owncloud the repository_owncloud object, which the tests are run on. */
     private $repo = null;

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -26,7 +26,8 @@ defined('MOODLE_INTERNAL') || die();
 
 /**
  * Class repository_owncloud_testcase
- * @group repository_owncloud
+ * @copyright  2017 Project seminar (Learnweb, University of Münster)
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class repository_owncloud_lib_testcase extends advanced_testcase {
 
@@ -101,7 +102,7 @@ class repository_owncloud_lib_testcase extends advanced_testcase {
     }
     /**
      * Returns an array of endpoints or null.
-     * @param $endpointname
+     * @param string $endpointname
      * @return array|null
      */
     private function get_endpoint_id($endpointname) {
@@ -801,8 +802,8 @@ XML;
     /**
      * Get private property
      *
-     * @param $refclass name of the class
-     * @param $propertyname name of the private property
+     * @param string $refclass name of the class
+     * @param string $propertyname name of the private property
      * @return ReflectionProperty the resulting reflection property.
      */
     protected function get_private_property($refclass, $propertyname) {
@@ -813,9 +814,9 @@ XML;
         return $property;
     }
     /**
-     * Helper method, which inserts a given owncloud mock object into the repository_owncloud object.
+     * Helper method, which inserts a given mock value into the repository_owncloud object.
      *
-     * @param $mock object mock object, which needs to be inserted.
+     * @param mixed $mock mock value, which needs to be inserted.
      * @return ReflectionProperty the resulting reflection property.
      */
     protected function set_private_property($mock, $value) {

--- a/tests/ocs_test.php
+++ b/tests/ocs_test.php
@@ -1,0 +1,66 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * This file contains tests for the repository_owncloud class.
+ *
+ * @package    repository_owncloud
+ * @copyright  2017 Jan Dageförde (Learnweb, University of Münster)
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+/**
+ * Class repository_owncloud_ocs_testcase
+ * @group repository_owncloud
+ */
+class repository_owncloud_ocs_testcase extends advanced_testcase {
+
+    /**
+     * @var \core\oauth2\issuer
+     */
+    private $issuer;
+
+
+    /**
+     * SetUp to create issuer and endpoints for OCS testing.
+     */
+    protected function setUp() {
+        $this->resetAfterTest(true);
+
+        // Admin is neccessary to create issuer object.
+        $this->setAdminUser();
+
+        $generator = $this->getDataGenerator()->get_plugin_generator('repository_owncloud');
+        $this->issuer = $generator->test_create_issuer();
+        $generator->test_create_endpoints($this->issuer->get('id'));
+    }
+
+    /**
+     * Test whether required REST API functions are declared.
+     */
+    public function test_api_functions() {
+        $mock = $this->createMock(\core\oauth2\client::class);
+        $mock->expects($this->once())->method('get_issuer')->willReturn($this->issuer);
+
+        $client = new \repository_owncloud\ocs_client($mock);
+        $functions = $client->get_api_functions();
+
+        // Assert that relevant (and used) functions are actually present.
+        $this->assertArrayHasKey('create_share', $functions);
+    }
+}

--- a/tests/ocs_test.php
+++ b/tests/ocs_test.php
@@ -26,7 +26,8 @@ defined('MOODLE_INTERNAL') || die();
 
 /**
  * Class repository_owncloud_ocs_testcase
- * @group repository_owncloud
+ * @copyright  2017 Jan Dageförde (Learnweb, University of Münster)
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 class repository_owncloud_ocs_testcase extends advanced_testcase {
 

--- a/tests/repository_owncloud_test.php
+++ b/tests/repository_owncloud_test.php
@@ -348,22 +348,45 @@ class repository_owncloud_testcase extends advanced_testcase {
         $mock = $this->getMockBuilder(\repository_owncloud\ocs_client::class)->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $file = '/datei';
         $expectedresponse = <<<XML
-<?xml version='1.0'?>
-<document>
- <title>sometitle</title>
- <data>
- <url>https://www.default.de</url>
- </data>
+<?xml version="1.0"?>
+<ocs>
  <meta>
- <statuscode>100</statuscode>
- <status>ok</status>
- <message/>
+  <status>ok</status>
+  <statuscode>100</statuscode>
+  <message/>
  </meta>
-</document>
+ <data>
+  <id>2</id>
+  <share_type>3</share_type>
+  <uid_owner>admin</uid_owner>
+  <displayname_owner>admin</displayname_owner>
+  <permissions>1</permissions>
+  <stime>1502883721</stime>
+  <parent/>
+  <expiration/>
+  <token>QXbqrJj8DcMaXen</token>
+  <uid_file_owner>admin</uid_file_owner>
+  <displayname_file_owner>admin</displayname_file_owner>
+  <path>/somefile</path>
+  <item_type>file</item_type>
+  <mimetype>application/pdf</mimetype>
+  <storage_id>home::admin</storage_id>
+  <storage>1</storage>
+  <item_source>6</item_source>
+  <file_source>6</file_source>
+  <file_parent>4</file_parent>
+  <file_target>/somefile</file_target>
+  <share_with/>
+  <share_with_displayname/>
+  <name/>
+  <url>https://www.default.test/somefile</url>
+  <mail_send>0</mail_send>
+ </data>
+</ocs>
 XML;
         // Expected Parameters.
         $ocsquery = [
-            'path' => urlencode($file),
+            'path' => $file,
             'shareType' => \repository_owncloud\ocs_client::SHARE_TYPE_PUBLIC,
             'publicUpload' => false,
             'permissions' => \repository_owncloud\ocs_client::SHARE_PERMISSION_READ
@@ -374,7 +397,7 @@ XML;
         $this->set_private_property($mock, 'ocsclient');
 
         // Method does extract the link from the xml format.
-        $this->assertEquals('https://www.default.de/download', $this->repo->get_link($file));
+        $this->assertEquals('https://www.default.test/somefile/download', $this->repo->get_link($file));
     }
 
     /**
@@ -393,21 +416,44 @@ XML;
         // Calls for get link(). Therefore, mocks for get_link are build.
         $mock = $this->getMockBuilder(\repository_owncloud\ocs_client::class)->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $expectedresponse = <<<XML
-<?xml version='1.0'?>
-<document>
- <title>sometitle</title>
- <data>
- <url>https://www.default.de/somefile</url>
- </data>
+<?xml version="1.0"?>
+<ocs>
  <meta>
- <statuscode>100</statuscode>
- <status>ok</status>
- <message/>
+  <status>ok</status>
+  <statuscode>100</statuscode>
+  <message/>
  </meta>
-</document>
+ <data>
+  <id>2</id>
+  <share_type>3</share_type>
+  <uid_owner>admin</uid_owner>
+  <displayname_owner>admin</displayname_owner>
+  <permissions>1</permissions>
+  <stime>1502883721</stime>
+  <parent/>
+  <expiration/>
+  <token>QXbqrJj8DcMaXen</token>
+  <uid_file_owner>admin</uid_file_owner>
+  <displayname_file_owner>admin</displayname_file_owner>
+  <path>/somefile</path>
+  <item_type>file</item_type>
+  <mimetype>application/pdf</mimetype>
+  <storage_id>home::admin</storage_id>
+  <storage>1</storage>
+  <item_source>6</item_source>
+  <file_source>6</file_source>
+  <file_parent>4</file_parent>
+  <file_target>/somefile</file_target>
+  <share_with/>
+  <share_with_displayname/>
+  <name/>
+  <url>https://www.default.test/somefile</url>
+  <mail_send>0</mail_send>
+ </data>
+</ocs>
 XML;
         // Expected Parameters.
-        $ocsquery = ['path' => urlencode($filename),
+        $ocsquery = ['path' => $filename,
             'shareType' => \repository_owncloud\ocs_client::SHARE_TYPE_PUBLIC,
             'publicUpload' => false,
             'permissions' => \repository_owncloud\ocs_client::SHARE_PERMISSION_READ,
@@ -418,7 +464,7 @@ XML;
         $this->set_private_property($mock, 'ocsclient');
 
         // Method redirects to get_link() and return the suitable value.
-        $this->assertEquals('https://www.default.de' . $filename . '/download', $this->repo->get_file_reference($filename));
+        $this->assertEquals('https://www.default.test' . $filename . '/download', $this->repo->get_file_reference($filename));
     }
 
     /**
@@ -541,7 +587,7 @@ XML;
         $generator = $this->getDataGenerator()->get_plugin_generator('repository_owncloud');
 
         $generator->test_create_single_endpoint($this->issuer->get('id'), "webdav_endpoint",
-            "https://www.default.de:8080/webdav/index.php");
+            "https://www.default.test:8080/webdav/index.php");
         $dav = $this->repo->initiate_webdavclient();
 
         $value = $this->get_private_property($dav, '_port');

--- a/tests/repository_owncloud_test.php
+++ b/tests/repository_owncloud_test.php
@@ -355,10 +355,9 @@ class repository_owncloud_testcase extends advanced_testcase {
  <url>https://www.default.de</url>
  </data>
  <meta>
- <statuscode>HTTP/1.1 200</statuscode>
- <status>
-   OK
- </status>
+ <statuscode>100</statuscode>
+ <status>ok</status>
+ <message/>
  </meta>
 </document>
 XML;
@@ -401,10 +400,9 @@ XML;
  <url>https://www.default.de/somefile</url>
  </data>
  <meta>
- <statuscode>HTTP/1.1 200</statuscode>
- <status>
-   OK
- </status>
+ <statuscode>100</statuscode>
+ <status>ok</status>
+ <message/>
  </meta>
 </document>
 XML;

--- a/tests/repository_owncloud_test.php
+++ b/tests/repository_owncloud_test.php
@@ -18,15 +18,11 @@
  * This file contains tests for the repository_owncloud class.
  *
  * @package     repository_owncloud
- * @group       repository_owncloud
- * @category    test
  * @copyright  2017 Project seminar (Learnweb, University of Münster)
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
 defined('MOODLE_INTERNAL') || die();
-
-global $CFG;
 
 /**
  * Class repository_owncloud_testcase

--- a/tests/repository_owncloud_test.php
+++ b/tests/repository_owncloud_test.php
@@ -549,15 +549,8 @@ XML;
         $value = $this->get_private_property($dav, '_port');
 
         $this->assertEquals('8080', $value->getValue($dav));
-
-        // Throws error for security reasons because Moodle only allows to create https connections.
-        // The exception is raised by a Moodle lib, though.
-        $this->expectException(core\invalid_persistent_exception::class);
-
-        $generator->test_create_single_endpoint($this->issuer->get('id'), "webdav_endpoint",
-            "http://www.default.de/webdav/index.php");
-        $this->repo->initiate_webdavclient();
     }
+
     /**
      * Test supported_filetypes.
      */

--- a/tests/repository_owncloud_test.php
+++ b/tests/repository_owncloud_test.php
@@ -382,7 +382,6 @@ XML;
      * Test get_file reference, merely returns the input if no optional_param is set.
      */
     public function test_get_file_reference_withoutoptionalparam() {
-        $this->repo->get_file_reference('/somefile');
         $this->assertEquals('/somefile', $this->repo->get_file_reference('/somefile'));
     }
 

--- a/version.php
+++ b/version.php
@@ -24,8 +24,8 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2017080401;        // The current plugin version (Date: YYYYMMDDXX).
+$plugin->version   = 2017081600;        // The current plugin version (Date: YYYYMMDDXX).
 $plugin->requires  = 2017051500;        // Requires Moodle 3.3 version.
 $plugin->component = 'repository_owncloud'; // Full name of the plugin (used for diagnostics).
-$plugin->release = 'v3.3-r5';
+$plugin->release = 'v3.3-r6';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
Improve the way shares are created (via OCS API) when a user requests a link to a file.

Short summary:
- Use an explicit OAuth-authenticated REST client for accessing the OCS API instead of ad-hoc curl calls.
- Raise explicit errors if the remote system produces invalid responses.
- Create new tests (and improve existing ones) that cover possible responses of the OCS API.
- Along the way, improve PHPDocs and fix (minor) Moodle prechecker warnings.