### PR TITLE
Update Plugin for Moodle 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ matrix:
 
 before_install:
   - phpenv config-rm xdebug.ini
-  - nvm install --lts
+  - nvm install 8.9.4
   - cd ../..
   - composer selfupdate
   - composer create-project -n --no-dev --prefer-dist moodlerooms/moodle-plugin-ci ci ^2

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -24,12 +24,15 @@
 namespace repository_owncloud\privacy;
 
 defined('MOODLE_INTERNAL') || die();
-
 use core_privacy\local\metadata\collection;
-
-class provider implements \core_privacy\local\metadata\provider {
-    public static function get_metadata(collection $collection) : collection {
-        // The repository uses a user specific acesstoken (called confirmation token), provided by the oauthlib, saved in the session to access files.
+class provider implements
+    \core_privacy\local\metadata\provider,
+    \core_privacy\local\request\plugin\provider {
+    use \core_privacy\local\legacy_polyfill;
+    public static function _get_metadata(collection $collection) {
+        // The repository uses a user specific acesstoken (called confirmation token), provided by the oauthlib, ...
+        // Saved in the session to access files. However, the oauthlib Privacy API is outsourced to the oauth2 plugin.
+        // For this reason the collections includes the oauth2 subplugin.
         $collection->add_subsystem_link(
             'auth_oauth2',
             [],

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -26,8 +26,7 @@ namespace repository_owncloud\privacy;
 defined('MOODLE_INTERNAL') || die();
 use core_privacy\local\metadata\collection;
 class provider implements
-    \core_privacy\local\metadata\provider,
-    \core_privacy\local\request\plugin\provider {
+    \core_privacy\local\metadata\provider {
     use \core_privacy\local\legacy_polyfill;
     public static function _get_metadata(collection $collection) {
         // The repository uses a user specific acesstoken (called confirmation token), provided by the oauthlib, ...

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -24,10 +24,16 @@
 namespace repository_owncloud\privacy;
 
 defined('MOODLE_INTERNAL') || die();
+
 use core_privacy\local\metadata\collection;
+use core_privacy\local\request\approved_contextlist;
+use core_privacy\local\request\contextlist;
+
 class provider implements
-    \core_privacy\local\metadata\provider {
+    \core_privacy\local\metadata\provider,
+    \core_privacy\local\request\plugin\provider {
     use \core_privacy\local\legacy_polyfill;
+
     public static function _get_metadata(collection $collection) {
         // The repository uses a user specific acesstoken (called confirmation token), provided by the oauthlib, ...
         // Saved in the session to access files. However, the oauthlib Privacy API is outsourced to the oauth2 plugin.
@@ -38,5 +44,39 @@ class provider implements
             'privacy:metadata:auth_oauth2'
         );
         return $collection;
+    }
+
+    /**
+     * Get the list of contexts that contain user information for the specified user.
+     *
+     * @param   int $userid The user to search.
+     * @return  contextlist   $contextlist  The contextlist containing the list of contexts used in this plugin.
+     */
+    public static function _get_contexts_for_userid($userid) {
+        return new contextlist();
+    }
+
+    /**
+     * Export all user data for the specified user, in the specified contexts.
+     *
+     * @param   approved_contextlist $contextlist The approved contexts to export information for.
+     */
+    public static function _export_user_data(approved_contextlist $contextlist) {
+    }
+
+    /**
+     * Delete all data for all users in the specified context.
+     *
+     * @param   context $context The specific context to delete data for.
+     */
+    public static function _delete_data_for_all_users_in_context(\context $context) {
+    }
+
+    /**
+     * Delete all user data for the specified user, in the specified contexts.
+     *
+     * @param   approved_contextlist $contextlist The approved contexts and user information to delete information for.
+     */
+    public static function _delete_data_for_user(approved_contextlist $contextlist) {
     }
 }

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -30,10 +30,9 @@ use core_privacy\local\metadata\collection;
 class provider implements \core_privacy\local\metadata\provider {
     public static function get_metadata(collection $collection) : collection {
         $collection->add_subsystem_link(
-            'oauthlib',
+            'auth_oauth2',
             [],
-            // TODO: is stored in the SESSION see lib/oauthlib.php l. 679 --> however, there exist no privacy class. 
-            'privacy:metadata:oauthlib'
+            'privacy:metadata:auth_oauth2'
         );
         return $collection;
     }

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -29,6 +29,7 @@ use core_privacy\local\metadata\collection;
 
 class provider implements \core_privacy\local\metadata\provider {
     public static function get_metadata(collection $collection) : collection {
+        // The repository uses a user specific acesstoken (called confirmation token), provided by the oauthlib, saved in the session to access files.
         $collection->add_subsystem_link(
             'auth_oauth2',
             [],

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -30,9 +30,11 @@ use core_privacy\local\metadata\collection;
 class provider implements \core_privacy\local\metadata\provider {
     public static function get_metadata(collection $collection) : collection {
         $collection->add_subsystem_link(
-            // TODO add core oauth 2
+            'oauthlib',
+            [],
+            // TODO: is stored in the SESSION see lib/oauthlib.php l. 679 --> however, there exist no privacy class. 
+            'privacy:metadata:oauthlib'
         );
-
         return $collection;
     }
 }

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -1,0 +1,38 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Provider Class to implement the Privacy API of Moodle35.
+ *
+ * @package    repository_owncloud
+ * @copyright  2018 Nina Herrmann (Learnweb, University of Münster)
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+namespace repository_owncloud\privacy;
+
+defined('MOODLE_INTERNAL') || die();
+
+use core_privacy\local\metadata\collection;
+
+class provider implements \core_privacy\local\metadata\provider {
+    public static function get_metadata(collection $collection) : collection {
+        $collection->add_subsystem_link(
+            // TODO add core oauth 2
+        );
+
+        return $collection;
+    }
+}

--- a/lang/en/repository_owncloud.php
+++ b/lang/en/repository_owncloud.php
@@ -40,6 +40,7 @@ $string['chooseissuer_help'] = 'To add a new issuer visit the admin OAuth 2 serv
 For additional help with the OAuth 2 API please refer to the Moodle documentation.';
 $string['chooseissuer_link'] = 'OAuth_2_services';
 $string['oauth2serviceslink'] = '<a href="{$a}" title="Link to OAuth 2 services configuration">OAuth 2 services configuration</a>';
+$string['privacy:metadata:auth_oauth2'] = 'The repository uses a acesstoken, provided by the oauthlib, saved in the Session to access files.';
 
 // Exceptions.
 $string['configuration_exception'] = 'An error in the configuration of the OAuth 2 client occurred: {$a}';

--- a/lang/en/repository_owncloud.php
+++ b/lang/en/repository_owncloud.php
@@ -40,7 +40,7 @@ $string['chooseissuer_help'] = 'To add a new issuer visit the admin OAuth 2 serv
 For additional help with the OAuth 2 API please refer to the Moodle documentation.';
 $string['chooseissuer_link'] = 'OAuth_2_services';
 $string['oauth2serviceslink'] = '<a href="{$a}" title="Link to OAuth 2 services configuration">OAuth 2 services configuration</a>';
-$string['privacy:metadata:auth_oauth2'] = 'The repository uses a acesstoken, provided by the oauthlib, saved in the Session to access files.';
+$string['privacy:metadata:auth_oauth2'] = 'The repository uses a user specific acesstoken (called confirmation token), provided by the oauthlib, saved in the session to access files.';
 
 // Exceptions.
 $string['configuration_exception'] = 'An error in the configuration of the OAuth 2 client occurred: {$a}';

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -27,6 +27,7 @@ defined('MOODLE_INTERNAL') || die();
 /**
  * Data generator for repository plugin.
  *
+ * @group repo_owncloud
  * @package    repository_owncloud
  * @copyright  2017 Project seminar (Learnweb, University of Münster)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -27,7 +27,7 @@ defined('MOODLE_INTERNAL') || die();
 /**
  * Data generator for repository plugin.
  *
- * @group repo_owncloud
+ * @group repository_owncloud
  * @package    repository_owncloud
  * @copyright  2017 Project seminar (Learnweb, University of Münster)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 /**
  * Class repository_owncloud_testcase
- * @group repo_owncloud
+ * @group repository_owncloud
  * @copyright  2017 Project seminar (Learnweb, University of Münster)
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -26,6 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 /**
  * Class repository_owncloud_testcase
+ * @group repo_owncloud
  * @copyright  2017 Project seminar (Learnweb, University of Münster)
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
@@ -560,6 +561,7 @@ XML;
         $mock->expects($this->exactly(2))->method('log_out');
         $this->set_private_property($mock, 'client');
         $this->repo->options['ajax'] = false;
+        $this->expectOutputString('<a target="_blank" rel="noopener noreferrer">Log in to your account</a><a target="_blank" rel="noopener noreferrer">Log in to your account</a>');
 
         $this->assertEquals($this->repo->print_login(), $this->repo->logout());
 

--- a/tests/ocs_test.php
+++ b/tests/ocs_test.php
@@ -26,6 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 /**
  * Class repository_owncloud_ocs_testcase
+ * @group repo_owncloud
  * @copyright  2017 Jan Dageförde (Learnweb, University of Münster)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */

--- a/tests/ocs_test.php
+++ b/tests/ocs_test.php
@@ -26,7 +26,7 @@ defined('MOODLE_INTERNAL') || die();
 
 /**
  * Class repository_owncloud_ocs_testcase
- * @group repo_owncloud
+ * @group repository_owncloud
  * @copyright  2017 Jan Dageförde (Learnweb, University of Münster)
  * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */


### PR DESCRIPTION
As part of the new Privacy API the following features have to be added:

- Describe the type of data that the plugin stores;
- Provide a way to export that data; and
- Provide a way to delete that data.

In case of this plugin a access token is stored temporary and considered as personal information. However, the plugin does not store the data directly but uses a subplugin. Therefore the implemented provider class list the oauth2 subplugin.