### PR TITLE
added a default expiration date for public links

### DIFF
--- a/classes/ocs_client.php
+++ b/classes/ocs_client.php
@@ -84,7 +84,8 @@ class ocs_client extends rest {
                     'path' => PARAM_TEXT, // Could be PARAM_PATH, we really don't want to enforce a Moodle understanding of paths.
                     'shareType' => PARAM_INT,
                     'publicUpload' => PARAM_RAW, // Actually Boolean, but neither String-Boolean ('false') nor PARAM_BOOL (0/1).
-                    'permissions' => PARAM_INT
+                    'permissions' => PARAM_INT,
+                    'expireDate' => PARAM_TEXT
                 ],
                 'response' => 'text/xml'
             ],

--- a/lib.php
+++ b/lib.php
@@ -254,6 +254,7 @@ class repository_owncloud extends repository {
 
     /**
      * Use OCS to generate a public share to the requested file.
+     * It sets a default expiration link of 10 years
      * This method derives a download link from the public share URL.
      *
      * @param string $url relative path to the chosen file
@@ -262,12 +263,16 @@ class repository_owncloud extends repository {
      *
      */
     public function get_link($url) {
+        // Todo this is set to ten years, however an issue will be opened for owncloud to enable endless expireDates
+        $expirationunix = time() + 315569260;
+        $expiration = (string) date('Y-m-d', $expirationunix);
         $ocsparams = [
             'path' => $url,
             'shareType' => ocs_client::SHARE_TYPE_PUBLIC,
             'publicUpload' => false,
-            'permissions' => ocs_client::SHARE_PERMISSION_READ
-            ];
+            'permissions' => ocs_client::SHARE_PERMISSION_READ,
+            'expireDate' => $expiration
+        ];
 
         $response = $this->ocsclient->call('create_share', $ocsparams);
         $xml = simplexml_load_string($response);


### PR DESCRIPTION
OwnCloud uses the standard expiration link when a new public link is created. 
However, this is complicated for uploading public links in Moodle since in most application scenarios links are supposed to persist for the whole duration of the course. 
Currently, it is not possible to set a endless `expirationDate` when creating the share. As a workaround all public links get a default value of 10 years. 
Single Links can still be changed manually in ownCloud.