### PR TITLE
[wip] Fix creation of folder structure in the system account

### DIFF
--- a/classes/access_controlled_link_manager.php
+++ b/classes/access_controlled_link_manager.php
@@ -250,31 +250,26 @@ class access_controlled_link_manager{
         // Extracts the end of the webdavendpoint.
         $parsedwebdavurl = $this->parse_endpoint_url('webdav');
         $webdavprefix = $parsedwebdavurl['path'];
+        $this->systemwebdavclient->open();
         // Checks whether folder exist and creates non-existent folders.
         foreach ($allfolders as $foldername) {
-            $this->systemwebdavclient->open();
             $fullpath .= '/' . $foldername;
             $isdir = $this->systemwebdavclient->is_dir($webdavprefix . $fullpath);
             // Folder already exist, continue.
             if ($isdir === true) {
-                $this->systemwebdavclient->close();
                 continue;
             }
-            $this->systemwebdavclient->open();
             $response = $this->systemwebdavclient->mkcol($webdavprefix . $fullpath);
 
-            $this->systemwebdavclient->close();
             if ($response != 201) {
-                $result['success'] = false;
-                continue;
+                $this->systemwebdavclient->close();
+                $details = get_string('contactadminwith', 'repository_owncloud',
+                    "Folder path $fullpath could not be created in the system account.");
+                throw new request_exception(array('instance' => $this->repositoryname,
+                    'errormessage' => $details));
             }
         }
-        if ($result['success'] != true) {
-            $details = get_string('contactadminwith', 'repository_owncloud',
-                'Folder path in the systemaccount could not be created.');
-            throw new request_exception(array('instance' => $this->repositoryname,
-                'errormessage' => $details));
-        }
+        $this->systemwebdavclient->close();
         $result['fullpath'] = $fullpath;
 
         return $result;


### PR DESCRIPTION
This started out as an endeavour to fix that folder structure creation sometimes fails. We succeeded at that, and fixed some more things along the way...

* In the error message, explicitly communicate **which** folder could not be created.
* Save one roundtrip to find out the user name of the system account (Moodle stored that already).
* Fix folder creation error: We need to clean for `PARAM_FILE`, not `PARAM_PATH` (slashes in name parts are problematic).

This is WIP; remaining work:
- [ ] If a file has been shared with the system account account: Don't fail, continue!
- [x] Check system account connectivity before using it (see TODO).
- [x] Simplify `$result` array in `create_folder_path_access_controlled_links`.