### PR TITLE
Fix creation of folder structure in the system account

### DIFF
--- a/classes/access_controlled_link_manager.php
+++ b/classes/access_controlled_link_manager.php
@@ -232,13 +232,13 @@ class access_controlled_link_manager{
                 $foldername .= ' (ctx '.$ctx->id.')';
             }
 
-            $foldername = clean_param($foldername, PARAM_PATH);
+            $foldername = clean_param($foldername, PARAM_FILE);
             $allfolders[] = $foldername;
         }
 
-        $allfolders[] = clean_param($component, PARAM_PATH);
-        $allfolders[] = clean_param($filearea, PARAM_PATH);
-        $allfolders[] = clean_param($itemid, PARAM_PATH);
+        $allfolders[] = clean_param($component, PARAM_FILE);
+        $allfolders[] = clean_param($filearea, PARAM_FILE);
+        $allfolders[] = clean_param($itemid, PARAM_FILE);
 
         // Extracts the end of the webdavendpoint.
         $parsedwebdavurl = $this->parse_endpoint_url('webdav');

--- a/classes/access_controlled_link_manager.php
+++ b/classes/access_controlled_link_manager.php
@@ -71,12 +71,11 @@ class access_controlled_link_manager{
     /**
      * Access_controlled_link_manager constructor.
      * @param ocs_client $ocsclient
+     * @param \core\oauth2\client $systemoauthclient
+     * @param ocs_client $systemocsclient
      * @param \core\oauth2\issuer $issuer
      * @param string $repositoryname
-     * @throws \coding_exception
-     * @throws \moodle_exception
      * @throws configuration_exception
-     * @throws request_exception
      */
     public function __construct($ocsclient, $systemoauthclient, $systemocsclient, $issuer, $repositoryname) {
         $this->ocsclient = $ocsclient;

--- a/classes/access_controlled_link_manager.php
+++ b/classes/access_controlled_link_manager.php
@@ -250,31 +250,26 @@ class access_controlled_link_manager{
         // Extracts the end of the webdavendpoint.
         $parsedwebdavurl = $this->parse_endpoint_url('webdav');
         $webdavprefix = $parsedwebdavurl['path'];
+        $this->systemwebdavclient->open();
         // Checks whether folder exist and creates non-existent folders.
         foreach ($allfolders as $foldername) {
-            $this->systemwebdavclient->open();
             $fullpath .= '/' . $foldername;
             $isdir = $this->systemwebdavclient->is_dir($webdavprefix . $fullpath);
             // Folder already exist, continue.
             if ($isdir === true) {
-                $this->systemwebdavclient->close();
                 continue;
             }
-            $this->systemwebdavclient->open();
             $response = $this->systemwebdavclient->mkcol($webdavprefix . $fullpath);
 
-            $this->systemwebdavclient->close();
             if ($response != 201) {
-                $result['success'] = false;
-                continue;
+                $this->systemwebdavclient->close();
+                $details = get_string('contactadminwith', 'repository_owncloud',
+                    "Folder path $fullpath could not be created in the system account.");
+                throw new request_exception(array('instance' => $this->repositoryname,
+                    'errormessage' => $details));
             }
         }
-        if ($result['success'] != true) {
-            $details = get_string('contactadminwith', 'repository_owncloud',
-                'Folder path in the systemaccount could not be created.');
-            throw new request_exception(array('instance' => $this->repositoryname,
-                'errormessage' => $details));
-        }
+        $this->systemwebdavclient->close();
         $result['fullpath'] = $fullpath;
 
         return $result;

--- a/classes/access_controlled_link_manager.php
+++ b/classes/access_controlled_link_manager.php
@@ -123,8 +123,8 @@ class access_controlled_link_manager{
         if ($username != null) {
             $shareusername = $username;
         } else {
-            $systemuserinfo = $this->systemoauthclient->get_userinfo();
-            $shareusername = $systemuserinfo['username'];
+            $systemaccount = \core\oauth2\api::get_system_account($this->issuer);
+            $shareusername = $systemaccount->get('username');
         }
         $permissions = ocs_client::SHARE_PERMISSION_READ;
         if ($maywrite) {

--- a/classes/access_controlled_link_manager.php
+++ b/classes/access_controlled_link_manager.php
@@ -78,19 +78,12 @@ class access_controlled_link_manager{
      * @throws configuration_exception
      * @throws request_exception
      */
-    public function __construct($ocsclient, $issuer, $repositoryname) {
+    public function __construct($ocsclient, $systemoauthclient, $systemocsclient, $issuer, $repositoryname) {
         $this->ocsclient = $ocsclient;
-        $this->systemoauthclient = api::get_system_oauth_client($issuer);
+        $this->systemoauthclient = $systemoauthclient;
+        $this->systemocsclient = $systemocsclient;
 
         $this->repositoryname = $repositoryname;
-        if ($this->systemoauthclient === false || $this->systemoauthclient->is_logged_in() === false) {
-            $details = get_string('contactadminwith', 'repository_owncloud',
-                'The systemaccount could not be connected.');
-            throw new request_exception(array('instance' => $repositoryname, 'errormessage' => $details));
-
-        } else {
-            $this->systemocsclient = new ocs_client($this->systemoauthclient);
-        }
         $this->issuer = $issuer;
         $this->systemwebdavclient = $this->create_system_dav();
     }

--- a/classes/access_controlled_link_manager.php
+++ b/classes/access_controlled_link_manager.php
@@ -193,23 +193,17 @@ class access_controlled_link_manager{
         return $result;
     }
 
-    /** Creates a unique folder path for the access controlled link.
+    /**
+     * Creates a unique folder path for the access controlled link.
      * @param context $context
      * @param string $component
      * @param string $filearea
      * @param string $itemid
-     * @return array $result success for the http status code and fullpath for the generated path.
-     * @throws configuration_exception
-     * @throws \coding_exception
-     * @throws \moodle_exception
-     * @throws \repository_owncloud\request_exception
+     * @return string $result full generated path.
+     * @throws request_exception If the folder path cannot be created.
      */
     public function create_folder_path_access_controlled_links($context, $component, $filearea, $itemid) {
         global $CFG, $SITE;
-        // Initialize the return array.
-        $result = array();
-        $result['success'] = true;
-
         // The fullpath to store the file is generated from the context.
         $contextlist = array_reverse($context->get_parent_contexts(true));
         $fullpath = '';
@@ -262,9 +256,7 @@ class access_controlled_link_manager{
             }
         }
         $this->systemwebdavclient->close();
-        $result['fullpath'] = $fullpath;
-
-        return $result;
+        return $fullpath;
     }
 
     /** Creates a new owncloud_client for the system account.

--- a/classes/test/testable_access_controlled_link_manager.php
+++ b/classes/test/testable_access_controlled_link_manager.php
@@ -25,6 +25,7 @@ namespace repository_owncloud\test;
 
 defined('MOODLE_INTERNAL') || die();
 
+use core\oauth2\client;
 use repository_owncloud\access_controlled_link_manager;
 use repository_owncloud\ocs_client;
 use repository_owncloud\owncloud_client;
@@ -41,12 +42,17 @@ class testable_access_controlled_link_manager extends access_controlled_link_man
     /**
      * Access_controlled_link_manager constructor.
      * @param ocs_client $ocsclient
+     * @param client $systemoauthclient
+     * @param ocs_client $systemocsclient
      * @param \core\oauth2\issuer $issuer
      * @param string $repositoryname
      * @param owncloud_client $systemdav
      */
-    public function __construct($ocsclient, \core\oauth2\issuer $issuer, $repositoryname, $systemdav) {
+    public function __construct($ocsclient, $systemoauthclient, $systemocsclient, \core\oauth2\issuer $issuer, $repositoryname,
+                                $systemdav) {
         $this->ocsclient = $ocsclient;
+        $this->systemoauthclient = $systemoauthclient;
+        $this->systemocsclient = $systemocsclient;
         $this->repositoryname = $repositoryname;
         $this->issuer = $issuer;
         $this->systemwebdavclient = $systemdav;

--- a/lib.php
+++ b/lib.php
@@ -349,7 +349,8 @@ class repository_owncloud extends repository {
             throw new repository_exception('cannotdownload', 'repository');
         }
 
-        $linkmanager = new \repository_owncloud\access_controlled_link_manager($this->ocsclient, $this->systemoauthclient, $this->systemocsclient, $this->issuer, $this->get_name());
+        $linkmanager = new \repository_owncloud\access_controlled_link_manager($this->ocsclient, $this->systemoauthclient,
+            $this->systemocsclient, $this->issuer, $this->get_name());
 
         // Get the current user.
         $userauth = $this->get_user_oauth_client();
@@ -408,7 +409,7 @@ class repository_owncloud extends repository {
         }
 
         // 1. assure the client and user is logged in.
-        if (empty($this->client)) {
+        if (empty($this->client) || $this->systemoauthclient === null || $this->systemocsclient === null) {
             $details = get_string('contactadminwith', 'repository_owncloud',
                 'The OAuth client could not be connected.');
             throw new \repository_owncloud\request_exception(array('instance' => $repositoryname, 'errormessage' => $details));
@@ -417,7 +418,6 @@ class repository_owncloud extends repository {
         if (!$this->client->is_logged_in()) {
             $this->print_login_popup(['style' => 'margin-top: 250px']);
             return;
-
         }
 
         // Determining writeability of file from the using context.
@@ -435,7 +435,6 @@ class repository_owncloud extends repository {
         $this->initiate_webdavclient();
 
         // Create the a manager to handle steps.
-        // TODO check system account connections first; maybe abort.
         $linkmanager = new \repository_owncloud\access_controlled_link_manager($this->ocsclient, $this->systemoauthclient, $this->systemocsclient, $this->issuer, $repositoryname);
 
         // 2. Check whether user has folder for files otherwise create it.

--- a/lib.php
+++ b/lib.php
@@ -366,11 +366,11 @@ class repository_owncloud extends repository {
         }
 
         // 2. Create a unique path in the system account.
-        $foldercreate = $linkmanager->create_folder_path_access_controlled_links($context, $component, $filearea,
+        $createdfolder = $linkmanager->create_folder_path_access_controlled_links($context, $component, $filearea,
             $itemid);
 
         // 3. Copy File to the new folder path.
-        $linkmanager->transfer_file_to_path($responsecreateshare['filetarget'], $foldercreate['fullpath'], 'copy');
+        $linkmanager->transfer_file_to_path($responsecreateshare['filetarget'], $createdfolder, 'copy');
 
         // 4. Delete the share.
         $linkmanager->delete_share_dataowner_sysaccount($responsecreateshare['shareid']);
@@ -378,7 +378,7 @@ class repository_owncloud extends repository {
         // Update the returned reference so that the stored_file in moodle points to the newly copied file.
         $filereturn = new stdClass();
         $filereturn->type = 'FILE_CONTROLLED_LINK';
-        $filereturn->link = $foldercreate['fullpath'] . $responsecreateshare['filetarget'];
+        $filereturn->link = $createdfolder . $responsecreateshare['filetarget'];
         $filereturn->name = $reference;
         $filereturn->usesystem = true;
         $filereturn = json_encode($filereturn);

--- a/lib.php
+++ b/lib.php
@@ -361,8 +361,8 @@ class repository_owncloud extends repository {
         // 1. Share the File with the system account.
         $responsecreateshare = $linkmanager->create_share_user_sysaccount($reference);
         if ($responsecreateshare['statuscode'] == 403) {
-            $details = get_string('filenotaccessed', 'repository_owncloud');
-            throw new \repository_owncloud\request_exception(array('instance' => $this->get_name(), 'errormessage' => $details));
+            // File has already been shared previously => find file in system account and use that.
+            $responsecreateshare = $linkmanager->find_share_in_sysaccount($reference);
         }
 
         // 2. Create a unique path in the system account.
@@ -435,7 +435,8 @@ class repository_owncloud extends repository {
         $this->initiate_webdavclient();
 
         // Create the a manager to handle steps.
-        $linkmanager = new \repository_owncloud\access_controlled_link_manager($this->ocsclient, $this->systemoauthclient, $this->systemocsclient, $this->issuer, $repositoryname);
+        $linkmanager = new \repository_owncloud\access_controlled_link_manager($this->ocsclient, $this->systemoauthclient,
+            $this->systemocsclient, $this->issuer, $repositoryname);
 
         // 2. Check whether user has folder for files otherwise create it.
         $linkmanager->create_storage_folder($this->controlledlinkfoldername, $this->dav);

--- a/tests/access_controlled_link_manager_test.php
+++ b/tests/access_controlled_link_manager_test.php
@@ -22,6 +22,8 @@
  * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
+use core\oauth2\system_account;
+
 defined('MOODLE_INTERNAL') || die();
 
 /**
@@ -39,6 +41,9 @@ class repository_owncloud_access_controlled_link_manager_testcase extends advanc
     /** @var null|\repository_owncloud\ocs_client The ocs_client used to send requests. */
     public $ocsmockclient = null;
 
+    /** @var null|\core\oauth2\client Mock oauth client for the system account. */
+    private $oauthsystemmock = null;
+
     /** @var null|\core\oauth2\issuer which belongs to the repository_owncloud object. */
     public $issuer = null;
 
@@ -54,43 +59,43 @@ class repository_owncloud_access_controlled_link_manager_testcase extends advanc
         $generator = $this->getDataGenerator()->get_plugin_generator('repository_owncloud');
         $this->issuer = $generator->test_create_issuer();
         $generator->test_create_endpoints($this->issuer->get('id'));
+
+        // Mock clients.
         $this->ocsmockclient = $this->getMockBuilder(repository_owncloud\ocs_client::class
+        )->disableOriginalConstructor()->disableOriginalClone()->getMock();
+        $this->oauthsystemmock = $this->getMockBuilder(\core\oauth2\client::class
         )->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $systemwebdavclient = $this->getMockBuilder(repository_owncloud\owncloud_client::class
         )->disableOriginalConstructor()->disableOriginalClone()->getMock();
+        $systemocsclient = $systemocsclient = $this->getMockBuilder(repository_owncloud\ocs_client::class
+        )->disableOriginalConstructor()->disableOriginalClone()->getMock();
+
+        // Pseudo system account user.
+        $this->systemaccountusername = 'pseudouser';
+        $record = new stdClass();
+        $record->issuerid = $this->issuer->get('id');
+        $record->refreshtoken = 'pseudotoken';
+        $record->grantedscopes = 'scopes';
+        $record->email = '';
+        $record->username = $this->systemaccountusername;
+        $systemaccount = new system_account(0, $record);
+        $systemaccount->create();
 
         $this->linkmanager = new \repository_owncloud\test\testable_access_controlled_link_manager($this->ocsmockclient,
+            $this->oauthsystemmock, $systemocsclient,
             $this->issuer, 'owncloud', $systemwebdavclient);
 
-    }
-
-    /**
-     * Tests whether class can be constructed.
-     */
-    public function test_construction() {
-        $mockclient = $this->getMockBuilder(\repository_owncloud\ocs_client::class
-        )->disableOriginalConstructor()->disableOriginalClone()->getMock();
-        // ExpectedException is here needed since the contructor of the linkmanager request whether the systemaccount is
-        // Logged in. This is checked in \core\oauth2\api.php get_system_oauth_client(l.293)
-        // However, since the client is newly created in the method and the method is static phpunit is not able to mock it.
-        $this->expectException('repository_owncloud\request_exception');
-        $this->linkmanager = new \repository_owncloud\access_controlled_link_manager($mockclient, $this->issuer, 'owncloud');
-
-        $mock = $this->createMock(\core\oauth2\client::class);
-        $mock->expects($this->once())->method('get_system_oauth_client')->with($this->issuer)->willReturn(true);
-        $this->linkmanager = new \repository_owncloud\access_controlled_link_manager($mockclient, $this->issuer, 'owncloud');
     }
 
     /**
      * Function to test the private function create_share_user_sysaccount.
      */
     public function test_create_share_user_sysaccount_user_shares() {
-        $username = 'user1';
         $params = [
             'path' => "/ambient.txt",
             'shareType' => \repository_owncloud\ocs_client::SHARE_TYPE_USER,
             'publicUpload' => false,
-            'shareWith' => $username,
+            'shareWith' => $this->systemaccountusername,
             'permissions' => \repository_owncloud\ocs_client::SHARE_PERMISSION_READ,
         ];
         $expectedresponse = <<<XML
@@ -130,10 +135,6 @@ class repository_owncloud_access_controlled_link_manager_testcase extends advanc
 XML;
         $this->ocsmockclient->expects($this->once())->method('call')->with('create_share', $params)->will(
             $this->returnValue($expectedresponse));
-
-        $clientmock = $this->createMock(\core\oauth2\client::class);
-        $clientmock->expects($this->once())->method('get_userinfo')->willReturn(array('username' => 'user1'));
-        $this->set_private_property($clientmock, 'systemoauthclient', $this->linkmanager);
 
         $result = $this->linkmanager->create_share_user_sysaccount("/ambient.txt");
         $xml = simplexml_load_string($expectedresponse);
@@ -192,13 +193,13 @@ XML;
     public function test_create_folder_path_folders_are_created() {
 
         // In Context is okay, number of context counts for number of iterations.
-        $mocks = $this->set_up_mocks_for_create_folder_path(false, 'somename/more', true, 201);
+        $mocks = $this->set_up_mocks_for_create_folder_path(false, 'somename/withslash', true, 201);
         $this->set_private_property($mocks['mockclient'], 'systemwebdavclient', $this->linkmanager);
         $result = $this->linkmanager->create_folder_path_access_controlled_links($mocks['mockcontext'], "mod_resource",
             'content', 0);
         $expected = array();
         $expected['success'] = true;
-        $expected['fullpath'] = '/somename/more (ctx )/mod_resource/content/0';
+        $expected['fullpath'] = '/somenamewithslash (ctx )/mod_resource/content/0';
         $this->assertEquals($expected, $result);
     }
     /**
@@ -229,12 +230,13 @@ XML;
         $parsedwebdavurl = parse_url($this->issuer->get_endpoint_url('webdav'));
         $webdavprefix = $parsedwebdavurl['path'];
         // Empty ctx 'id' expected because using code will not be able to access $ctx->id.
-        $dirstring = $webdavprefix . '/' . $returnestedcontext . ' (ctx )';
-        $mockclient->expects($this->exactly(4))->method('is_dir')->with($this->logicalOr(
+        $cleanedcontextname = clean_param($returnestedcontext, PARAM_FILE);
+        $dirstring = $webdavprefix . '/' . $cleanedcontextname . ' (ctx )';
+        $mockclient->expects($this->atMost(4))->method('is_dir')->with($this->logicalOr(
             $dirstring, $dirstring . '/mod_resource', $dirstring . '/mod_resource/content',
             $dirstring . '/mod_resource/content/0'))->willReturn($returnisdir);
         if ($callmkcol == true) {
-            $mockclient->expects($this->exactly(4))->method('mkcol')->willReturn($returnmkcol);
+            $mockclient->expects($this->atMost(4))->method('mkcol')->willReturn($returnmkcol);
         }
         $mockcontext->method('get_parent_contexts')->willReturn(array('1' => $mockcontext));
         $mockcontext->method('get_context_name')->willReturn($returnestedcontext);
@@ -444,13 +446,10 @@ XML;
      */
     public function test_create_system_dav() {
         // Initialize mock and params.
-        $oauthclientmock = $this->getMockBuilder(\core\oauth2\client::class
-        )->disableOriginalConstructor()->disableOriginalClone()->getMock();
         $fakeaccesstoken = new stdClass();
         $fakeaccesstoken->token = "fake access token";
         // Use `atLeastOnce` instead of `exactly(2)` because it is only called a second time on dev systems that allow http://.
-        $oauthclientmock->expects($this->atLeastOnce())->method('get_accesstoken')->willReturn($fakeaccesstoken);
-        $this->set_private_property($oauthclientmock, 'systemoauthclient', $this->linkmanager);
+        $this->oauthsystemmock->expects($this->atLeastOnce())->method('get_accesstoken')->willReturn($fakeaccesstoken);
         $parsedwebdavurl = parse_url($this->issuer->get_endpoint_url('webdav'));
 
         // Call function and create own client.

--- a/tests/access_controlled_link_manager_test.php
+++ b/tests/access_controlled_link_manager_test.php
@@ -180,11 +180,7 @@ XML;
         $this->set_private_property($mocks['mockclient'], 'systemwebdavclient', $this->linkmanager);
         $result = $this->linkmanager->create_folder_path_access_controlled_links($mocks['mockcontext'], "mod_resource",
             'content', 0);
-        $expected = array();
-        $expected['success'] = true;
-        // Empty ctx 'id' expected because using code will not be able to access $ctx->id.
-        $expected['fullpath'] = '/somename (ctx )/mod_resource/content/0';
-        $this->assertEquals($expected, $result);
+        $this->assertEquals('/somename (ctx )/mod_resource/content/0', $result);
     }
     /**
      * Function which test that create folder path does return the adequate results (path and success).
@@ -197,10 +193,7 @@ XML;
         $this->set_private_property($mocks['mockclient'], 'systemwebdavclient', $this->linkmanager);
         $result = $this->linkmanager->create_folder_path_access_controlled_links($mocks['mockcontext'], "mod_resource",
             'content', 0);
-        $expected = array();
-        $expected['success'] = true;
-        $expected['fullpath'] = '/somenamewithslash (ctx )/mod_resource/content/0';
-        $this->assertEquals($expected, $result);
+        $this->assertEquals('/somenamewithslash (ctx )/mod_resource/content/0', $result);
     }
     /**
      * Test whether the create_folder_path methode throws exception.


### PR DESCRIPTION
This started out as an endeavour to fix that folder structure creation sometimes fails. We succeeded at that, and fixed some more things along the way...

* In the error message, explicitly communicate **which** folder could not be created.
* Save one roundtrip to find out the user name of the system account (Moodle stored that already).
* Fix folder creation error: We need to clean for `PARAM_FILE`, not `PARAM_PATH` (slashes in name parts were problematic previously).
* Check system account connectivity before using it in `send_file`.
* Simplify `$result` array in `create_folder_path_access_controlled_links`.
* If a file has been shared with the system account: Don't fail, continue!

(replaces #36)