### PR TITLE
Output access controlled links via Moodle instead of performing a redirect

### DIFF
--- a/lang/en/repository_owncloud.php
+++ b/lang/en/repository_owncloud.php
@@ -54,7 +54,6 @@ $string['fileoptions'] = 'The types and defaults for returned files is configura
 $string['configuration_exception'] = 'An error in the configuration of the OAuth 2 client occurred: {$a}';
 $string['request_exception'] = 'A request to {$a->instance} has failed. {$a->errormessage}';
 $string['requestnotexecuted'] = 'The request could not be executed. If this happens frequently please contact the course or site administrator.';
-$string['downloadpopup'] = 'The requested file is additionally stored in your {$a->instancename} instance in the {$a->foldername} folder.';
 $string['notauthorized'] = 'You are not authorized to execute the demanded request. Please ensure you are authenticated with the right account.';
 $string['contactadminwith'] = 'The requested action could not be executed. In case this happens frequently please contact the side administrator with the following additional information:<br>"<i>{$a}</i>"';
 $string['cannotconnect'] = 'The user could not be authenticated, please log in and then upload the file.';


### PR DESCRIPTION
This is mandated by Nextcloud, because Nextcloud increasingly uses
samesite cookies. Therefore, if we redirect requests for files to
Nextcloud in the browser, the browser is not authenticated in Nextcloud.
As a consequence, redirects did not work. This is a workaround that
first loads the file into Moodle into a per-request directory. 

We use `send_temp_file`, thus ensuring that 
a) the file is deleted immediately afterwards, and 
b) configured accelerator mechanisms are used.